### PR TITLE
refactor: ExtensionManagerImpl use system property to load advanced

### DIFF
--- a/src/main/java/org/openzal/zal/extension/ExtensionManagerImpl.java
+++ b/src/main/java/org/openzal/zal/extension/ExtensionManagerImpl.java
@@ -55,6 +55,14 @@ class ExtensionManagerImpl implements ExtensionManager
     mExtensionDirectory = getCurrentJarDirectory();
   }
 
+  public ExtensionManagerImpl(File parentJarDirectory)
+  {
+    mCustomClassLoader = null;
+    mCustomZalExtensionController = null;
+    mExtension = null;
+    mExtensionDirectory = parentJarDirectory;
+  }
+
   @Override
   public void setCustomClassLoader(ClassLoader classLoader)
   {

--- a/src/main/java/org/openzal/zal/extension/Utils.java
+++ b/src/main/java/org/openzal/zal/extension/Utils.java
@@ -1,5 +1,0 @@
-package org.openzal.zal.extension;
-
-public class Utils {
-
-}

--- a/src/main/java/org/openzal/zal/extension/Utils.java
+++ b/src/main/java/org/openzal/zal/extension/Utils.java
@@ -1,0 +1,5 @@
+package org.openzal.zal.extension;
+
+public class Utils {
+
+}

--- a/src/main/java/org/openzal/zal/extension/ZalEntrypointImpl.java
+++ b/src/main/java/org/openzal/zal/extension/ZalEntrypointImpl.java
@@ -20,6 +20,7 @@
 
 package org.openzal.zal.extension;
 
+import java.util.Objects;
 import javax.annotation.Nullable;
 import org.openzal.zal.BuildProperties;
 import org.openzal.zal.ZalVersion;
@@ -45,9 +46,6 @@ public class ZalEntrypointImpl implements ZalEntrypoint
   @Nullable
   private WeakReference<ClassLoader> mPreviousExtension;
 
-  private static final String ZAL_FILE     = "/zal.jar";
-  private static final String ZEXTRAS_FILE = "/carbonio.jar";
-
   public ZalEntrypointImpl()
   {
     mExtensionManager = null;
@@ -65,9 +63,12 @@ public class ZalEntrypointImpl implements ZalEntrypoint
     {
       if (mExtensionManager == null)
       {
-        mExtensionManager = (ExtensionManager) this.getClass().getClassLoader().loadClass(
-          "org.openzal.zal.extension.ExtensionManagerImpl"
-        ).newInstance();
+        String carbonioJarDirectory = System.getProperty("carbonioJarDirectory");
+        if (Objects.isNull(carbonioJarDirectory) || carbonioJarDirectory.isEmpty()) {
+          mExtensionManager = new ExtensionManagerImpl();
+        } else {
+          mExtensionManager = new ExtensionManagerImpl(new File(carbonioJarDirectory));
+        }
       }
 
       return mExtensionManager;


### PR DESCRIPTION
These changes allow loading carbonio jar from a different location.
While testing we noticed ZAL is using classpath to infer location where carbonio.jar (or ani ZAL-Extension) is loaded, by assuming it is in some parent directory. 
I thought it was more simple and flexible to just setup the directory of carbonio.jar is located, without much thinking.