### PR TITLE
refactor: adapt to new mailbox methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <revision>4.31.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <carbonio.version>4.27.9</carbonio.version>
+    <carbonio.version>4.27.12</carbonio.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson.version>2.15.4</jackson.version>
     <jfreechart.version>1.0.15</jfreechart.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <revision>4.31.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <carbonio.version>4.27.6</carbonio.version>
+    <carbonio.version>4.27.7-SNAPSHOT</carbonio.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson.version>2.15.4</jackson.version>
     <jfreechart.version>1.0.15</jfreechart.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <revision>4.31.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <carbonio.version>4.27.7-SNAPSHOT</carbonio.version>
+    <carbonio.version>4.27.9</carbonio.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson.version>2.15.4</jackson.version>
     <jfreechart.version>1.0.15</jfreechart.version>

--- a/src/main/java/org/openzal/zal/ProvisioningImp.java
+++ b/src/main/java/org/openzal/zal/ProvisioningImp.java
@@ -70,8 +70,6 @@ import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.admin.type.GranteeSelector.GranteeBy;
 import com.zimbra.soap.type.GalSearchType;
 import com.zimbra.soap.type.TargetBy;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.*;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
@@ -82,7 +80,7 @@ import org.openzal.zal.exceptions.ZimbraException;
 import org.openzal.zal.lib.Filter;
 import org.openzal.zal.log.ZimbraLog;
 import org.openzal.zal.provisioning.DirectQueryFilterBuilder;
-import org.openzal.zal.provisioning.TargetType;
+
 
 public class ProvisioningImp implements Provisioning
 {

--- a/src/main/java/org/openzal/zal/ProvisioningImp.java
+++ b/src/main/java/org/openzal/zal/ProvisioningImp.java
@@ -329,6 +329,11 @@ public class ProvisioningImp implements Provisioning
 
   private final AuthProvider mAuthProvider = new AuthProvider();
 
+  private LdapClient getLdapClient()
+  {
+    return ((LdapProv) mProvisioning).getLdapClient();
+  }
+
   public ProvisioningImp()
   {
     this(com.zimbra.cs.account.Provisioning.getInstance());
@@ -1597,19 +1602,20 @@ public class ProvisioningImp implements Provisioning
     ZLdapContext zlc = null;
     ZMutableEntry entry = null;
     String dn = null;
+    final LdapProvisioning ldapProvisioning = (LdapProvisioning) mProvisioning;
     try
     {
-      zlc = LdapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_ACCOUNT);
-      entry = LdapClient.createMutableEntry();
+      final LdapClient ldapClient = ldapProvisioning.getLdapClient();
+      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_ACCOUNT);
+      entry = ldapClient.createInstanceMutableEntry();
       entry.mapToAttrs(attrs);
       //dn = "cn="+LdapUtil.escapeRDNValue(attributes.get("cn").toString())+",cn=cos,cn=zimbra";
-      LdapProvisioning provisioning = (LdapProvisioning)mProvisioning;
 
       String[] parts = emailAddress.split("@");
       String localPart = parts[0];
       String domain = parts[1];
 
-      dn = provisioning.getDIT().accountDNCreate(
+      dn = ldapProvisioning.getDIT().accountDNCreate(
         null,
         entry.getAttributes(),
         localPart,
@@ -1640,7 +1646,7 @@ public class ProvisioningImp implements Provisioning
     }
     finally
     {
-      LdapClient.closeContext(zlc);
+      ldapProvisioning.getLdapClient().closeInstanceContext(zlc);
     }
   }
 
@@ -1710,8 +1716,8 @@ public class ProvisioningImp implements Provisioning
     String dn = null;
     try
     {
-      zlc = LdapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_COS);
-      entry = LdapClient.createMutableEntry();
+      zlc = getLdapClient().getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_COS);
+      entry = getLdapClient().createInstanceMutableEntry();
       entry.mapToAttrs(attributes);
       dn = "cn="+LdapUtil.escapeRDNValue(attributes.get("cn").toString())+",cn=cos,cn=zimbra";
       entry.setDN(dn);
@@ -1738,7 +1744,7 @@ public class ProvisioningImp implements Provisioning
     }
     finally
     {
-      LdapClient.closeContext(zlc);
+      getLdapClient().closeInstanceContext(zlc);
     }
   }
 
@@ -1815,7 +1821,7 @@ public class ProvisioningImp implements Provisioning
       }
       dn = stringBuffer.substring(0, stringBuffer.length()-1);
 
-      zlc = LdapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_DOMAIN);
+      zlc = getLdapClient().getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_DOMAIN);
 
       LdapProvisioning provisioning = (LdapProvisioning)mProvisioning;
 
@@ -1825,7 +1831,7 @@ public class ProvisioningImp implements Provisioning
         createParentDomains(zlc, parts, dns);
       }
 
-      entry = LdapClient.createMutableEntry();
+      entry = getLdapClient().createInstanceMutableEntry();
       entry.mapToAttrs(attributes);
       entry.setDN(dn);
       ZimbraLog.mailbox.info("Restoring domain "+dn);
@@ -1858,7 +1864,7 @@ public class ProvisioningImp implements Provisioning
     }
     finally
     {
-      LdapClient.closeContext(zlc);
+      getLdapClient().closeInstanceContext(zlc);
     }
   }
 
@@ -1880,8 +1886,8 @@ public class ProvisioningImp implements Provisioning
       }
 
       dn = "uid="+LdapUtil.escapeRDNValue(local)+",ou=people"+dc;
-      zlc = LdapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_DISTRIBUTIONLIST);
-      entry = LdapClient.createMutableEntry();
+      zlc = getLdapClient().getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_DISTRIBUTIONLIST);
+      entry = getLdapClient().createInstanceMutableEntry();
       entry.mapToAttrs(attributes);
       entry.setDN(dn);
       ZimbraLog.mailbox.info("Restoring distribution list "+dn);
@@ -1907,7 +1913,7 @@ public class ProvisioningImp implements Provisioning
     }
     finally
     {
-      LdapClient.closeContext(zlc);
+      getLdapClient().closeInstanceContext(zlc);
     }
   }
 
@@ -2990,7 +2996,7 @@ public class ProvisioningImp implements Provisioning
   {
     ZLdapContext zlc = null;
     try {
-      zlc = LdapClient.getContext(LdapServerType.REPLICA, LdapUsage.GENERIC);
+      zlc = getLdapClient().getInstanceContext(LdapServerType.REPLICA, LdapUsage.GENERIC);
       LDAPConnection connection = zlc.getNative();
 
 
@@ -3053,7 +3059,7 @@ public class ProvisioningImp implements Provisioning
       throw ExceptionWrapper.wrap(ex);
     }
     finally {
-      LdapClient.closeContext(zlc);
+      getLdapClient().closeInstanceContext(zlc);
     }
   }
 
@@ -3069,7 +3075,7 @@ public class ProvisioningImp implements Provisioning
         (String[]) null
       );
 
-      zlc = LdapClient.getContext(LdapServerType.REPLICA, LdapUsage.GENERIC);
+      zlc = getLdapClient().getInstanceContext(LdapServerType.REPLICA, LdapUsage.GENERIC);
       return (int)zlc.countEntries(
         base,
         DirectQueryFilterBuilder.create(query),
@@ -3086,7 +3092,7 @@ public class ProvisioningImp implements Provisioning
     }
     finally
     {
-      LdapClient.closeContext(zlc);
+      getLdapClient().closeInstanceContext(zlc);
     }
   }
 

--- a/src/main/java/org/openzal/zal/ProvisioningImp.java
+++ b/src/main/java/org/openzal/zal/ProvisioningImp.java
@@ -82,6 +82,7 @@ import org.openzal.zal.exceptions.ZimbraException;
 import org.openzal.zal.lib.Filter;
 import org.openzal.zal.log.ZimbraLog;
 import org.openzal.zal.provisioning.DirectQueryFilterBuilder;
+import org.openzal.zal.provisioning.TargetType;
 
 public class ProvisioningImp implements Provisioning
 {
@@ -1748,56 +1749,10 @@ public class ProvisioningImp implements Provisioning
     }
   }
 
-  private final static Method sCreateParentDomains;
-  static
-  {
-    try
-    {
-      sCreateParentDomains = com.zimbra.cs.account.ldap.LdapProvisioning.class.getDeclaredMethod(
-        "createParentDomains",
-        ZLdapContext.class,
-        String[].class,
-        String[].class
-      );
-      sCreateParentDomains.setAccessible(true);
-    }
-    catch (Throwable ex)
-    {
-      ZimbraLog.extensions.fatal("ZAL Reflection Initialization Exception: " + Utils.exceptionToString(ex));
-      throw new RuntimeException(ex);
-    }
-  }
-
 
   private void createParentDomains(ZLdapContext zlc, String[] parts, String[] dns) throws ServiceException
   {
-    try
-    {
-      sCreateParentDomains.invoke(mProvisioning,zlc,parts,dns);
-    }
-    catch (IllegalAccessException e)
-    {
-      throw new RuntimeException(e);
-    }
-    catch (InvocationTargetException e)
-    {
-      try
-      {
-        throw e.getCause();
-      }
-      catch (RuntimeException ex)
-      {
-        throw ex;
-      }
-      catch (ServiceException ex)
-      {
-        throw ex;
-      }
-      catch (Throwable throwable)
-      {
-        throw new RuntimeException(throwable);
-      }
-    }
+    ((LdapProvisioning) mProvisioning).createParentDomains(zlc, parts, dns);
   }
 
   @Override

--- a/src/main/java/org/openzal/zal/ProvisioningImp.java
+++ b/src/main/java/org/openzal/zal/ProvisioningImp.java
@@ -1606,8 +1606,8 @@ public class ProvisioningImp implements Provisioning
     try
     {
       final LdapClient ldapClient = ldapProvisioning.getLdapClient();
-      zlc = ldapClient.getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_ACCOUNT);
-      entry = ldapClient.createInstanceMutableEntry();
+      zlc = ldapClient.getContext(LdapServerType.MASTER, LdapUsage.CREATE_ACCOUNT);
+      entry = ldapClient.createMutableEntry();
       entry.mapToAttrs(attrs);
       //dn = "cn="+LdapUtil.escapeRDNValue(attributes.get("cn").toString())+",cn=cos,cn=zimbra";
 
@@ -1646,7 +1646,7 @@ public class ProvisioningImp implements Provisioning
     }
     finally
     {
-      ldapProvisioning.getLdapClient().closeInstanceContext(zlc);
+      ldapProvisioning.getLdapClient().closeContext(zlc);
     }
   }
 
@@ -1716,8 +1716,8 @@ public class ProvisioningImp implements Provisioning
     String dn = null;
     try
     {
-      zlc = getLdapClient().getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_COS);
-      entry = getLdapClient().createInstanceMutableEntry();
+      zlc = getLdapClient().getContext(LdapServerType.MASTER, LdapUsage.CREATE_COS);
+      entry = getLdapClient().createMutableEntry();
       entry.mapToAttrs(attributes);
       dn = "cn="+LdapUtil.escapeRDNValue(attributes.get("cn").toString())+",cn=cos,cn=zimbra";
       entry.setDN(dn);
@@ -1744,7 +1744,7 @@ public class ProvisioningImp implements Provisioning
     }
     finally
     {
-      getLdapClient().closeInstanceContext(zlc);
+      getLdapClient().closeContext(zlc);
     }
   }
 
@@ -1821,7 +1821,7 @@ public class ProvisioningImp implements Provisioning
       }
       dn = stringBuffer.substring(0, stringBuffer.length()-1);
 
-      zlc = getLdapClient().getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_DOMAIN);
+      zlc = getLdapClient().getContext(LdapServerType.MASTER, LdapUsage.CREATE_DOMAIN);
 
       LdapProvisioning provisioning = (LdapProvisioning)mProvisioning;
 
@@ -1831,7 +1831,7 @@ public class ProvisioningImp implements Provisioning
         createParentDomains(zlc, parts, dns);
       }
 
-      entry = getLdapClient().createInstanceMutableEntry();
+      entry = getLdapClient().createMutableEntry();
       entry.mapToAttrs(attributes);
       entry.setDN(dn);
       ZimbraLog.mailbox.info("Restoring domain "+dn);
@@ -1864,7 +1864,7 @@ public class ProvisioningImp implements Provisioning
     }
     finally
     {
-      getLdapClient().closeInstanceContext(zlc);
+      getLdapClient().closeContext(zlc);
     }
   }
 
@@ -1886,8 +1886,8 @@ public class ProvisioningImp implements Provisioning
       }
 
       dn = "uid="+LdapUtil.escapeRDNValue(local)+",ou=people"+dc;
-      zlc = getLdapClient().getInstanceContext(LdapServerType.MASTER, LdapUsage.CREATE_DISTRIBUTIONLIST);
-      entry = getLdapClient().createInstanceMutableEntry();
+      zlc = getLdapClient().getContext(LdapServerType.MASTER, LdapUsage.CREATE_DISTRIBUTIONLIST);
+      entry = getLdapClient().createMutableEntry();
       entry.mapToAttrs(attributes);
       entry.setDN(dn);
       ZimbraLog.mailbox.info("Restoring distribution list "+dn);
@@ -1913,7 +1913,7 @@ public class ProvisioningImp implements Provisioning
     }
     finally
     {
-      getLdapClient().closeInstanceContext(zlc);
+      getLdapClient().closeContext(zlc);
     }
   }
 
@@ -2996,7 +2996,7 @@ public class ProvisioningImp implements Provisioning
   {
     ZLdapContext zlc = null;
     try {
-      zlc = getLdapClient().getInstanceContext(LdapServerType.REPLICA, LdapUsage.GENERIC);
+      zlc = getLdapClient().getContext(LdapServerType.REPLICA, LdapUsage.GENERIC);
       LDAPConnection connection = zlc.getNative();
 
 
@@ -3059,7 +3059,7 @@ public class ProvisioningImp implements Provisioning
       throw ExceptionWrapper.wrap(ex);
     }
     finally {
-      getLdapClient().closeInstanceContext(zlc);
+      getLdapClient().closeContext(zlc);
     }
   }
 
@@ -3075,7 +3075,7 @@ public class ProvisioningImp implements Provisioning
         (String[]) null
       );
 
-      zlc = getLdapClient().getInstanceContext(LdapServerType.REPLICA, LdapUsage.GENERIC);
+      zlc = getLdapClient().getContext(LdapServerType.REPLICA, LdapUsage.GENERIC);
       return (int)zlc.countEntries(
         base,
         DirectQueryFilterBuilder.create(query),
@@ -3092,7 +3092,7 @@ public class ProvisioningImp implements Provisioning
     }
     finally
     {
-      getLdapClient().closeInstanceContext(zlc);
+      getLdapClient().closeContext(zlc);
     }
   }
 


### PR DESCRIPTION
Zal provisioningImp needs to access ldap client. The methods are the same but the instance is exposed through provisioning.
One issue is that ZAL expects a Provisioning abstraction, but then explicitly calls ldap methods.

Perhaps the ZAL was made to work with LdapProvisioning and not Provisioning.
The code was hiding until now because it was accessed through static calls instead of using dependencies/collaborators.

Example of when things can go wrong: if someone passes SoapProvisioning the methods will fail.

It would be better also if some methods were not accessible from ldapClient, but directly in ldapProvisioning

### Note
- there were already some casts in the code, for example when ZAL calls methods by reflection casting LdapProvisioning -> **removed in favor of public method**
```
static
  {
    try
    {
      sCreateParentDomains = com.zimbra.cs.account.ldap.LdapProvisioning.class.getDeclaredMethod(
        "createParentDomains",
        ZLdapContext.class,
        String[].class,
        String[].class
      );
      sCreateParentDomains.setAccessible(true);
    }
```