### PR TITLE
fix(ci): update jenkins-lib-common to v2.8.8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-        identifier: 'jenkins-lib-common@1.7.5',
+        identifier: 'jenkins-lib-common@v2.8.8',
         retriever: modernSCM([
                 $class: 'GitSCMSource',
                 credentialsId: 'jenkins-integration-with-github-account',
@@ -79,14 +79,7 @@ pipeline {
                     }
                     steps {
                         script {
-                            def yapFiles = [
-                                'yap.json'
-                            ] as Set
-                            def packages = yapHelper.getPackageNamesFromFiles(yapFiles)
-
-                            uploadStage([
-                                packages: packages,
-                            ])
+                            uploadStage()
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- Bump `jenkins-lib-common` from `1.7.5` to `v2.8.8`
- Remove the `packages:` argument from `uploadStage()` — it was **removed in v2** and now triggers a hard `error` at runtime; packages are resolved internally from `yap.json`
- Drop the now-dead `yapHelper.getPackageNamesFromFiles()` call