### PR TITLE
fix: mark jackson-databind as provided, matching the rest of zal's scope pattern

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,10 +134,15 @@
       <version>3.0.2</version>
     </dependency>
 
+    <!-- provided: zal is meant to run against whatever jackson version the
+         host process (carbonio-mailbox) already has loaded; bundling our
+         own copy just duplicates it in every consumer's extension jar.
+         Matches the javax.activation-api/javax.mail-api pattern below. -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
zal is meant to run against whatever the host carbonio-mailbox process already has on its classpath - that's why javax.activation-api and javax.mail-api are already declared `provided` right next to this dependency. jackson-databind (which transitively pulls jackson-core and jackson-annotations) was left at the default compile scope, so every consumer bundles its own duplicate copy of a library the host process already loads, for no benefit.

Found while tracing the last unexplained jackson-core/jackson-databind copies left in carbonio-advanced's shipped dependency set after excluding the other leaks (see the chore/shrink-extension-artifact-size branch on carbonio-advanced). Consumers only see the effect once they bump their openzal-version to whatever release includes this change.